### PR TITLE
Disk queue fix

### DIFF
--- a/pkg/disk/queue.go
+++ b/pkg/disk/queue.go
@@ -35,6 +35,12 @@ func New(dataDir string, fileSize int) (*Queue, error) {
 			}
 			if data == nil {
 				time.Sleep(delay)
+				select {
+				case <-q.stop:
+					return
+				default:
+					continue
+				}
 			}
 			select {
 			case <-q.stop:


### PR DESCRIPTION
./grayproxy -out tcp://127.0.0.1:12201 -dataDir=./cache

2019/07/19 23:25:05 Added input 0 at udp://:12201
2019/07/19 23:25:05 adding output 0: tcp://127.0.0.1:12201
2019/07/19 23:25:05 starting grayproxy
2019/07/19 23:25:05 out 0: writing TCP: write tcp 127.0.0.1:52618->127.0.0.1:12201: write: broken pipe
2019/07/19 23:25:05 out 0 is now alive
2019/07/19 23:25:05 out 0: writing TCP: write tcp 127.0.0.1:52622->127.0.0.1:12201: write: broken pipe
2019/07/19 23:25:05 out 0 is now alive
....
