### PR TITLE
Add tls sender

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/andviro/grayproxy/pkg/http"
 	"github.com/andviro/grayproxy/pkg/loki"
 	"github.com/andviro/grayproxy/pkg/tcp"
+	"github.com/andviro/grayproxy/pkg/tls"
 	"github.com/andviro/grayproxy/pkg/udp"
 	"github.com/andviro/grayproxy/pkg/ws"
 	"github.com/pkg/errors"
@@ -100,6 +101,8 @@ func (app *app) configure() error {
 			app.outs = append(app.outs, wss)
 		case strings.HasPrefix(v, "udp://"):
 			app.outs = append(app.outs, &udp.Sender{Address: strings.TrimPrefix(v, "udp://"), SendTimeout: app.sendTimeout})
+		case strings.HasPrefix(v, "tls://"):
+			app.outs = append(app.outs, &tls.Sender{Address: strings.TrimPrefix(v, "tls://"), SendTimeout: app.sendTimeout})
 		default:
 			app.outs = append(app.outs, &tcp.Sender{Address: strings.TrimPrefix(v, "tcp://"), SendTimeout: app.sendTimeout})
 		}

--- a/pkg/tls/sender.go
+++ b/pkg/tls/sender.go
@@ -1,0 +1,49 @@
+package tls
+
+import (
+	"net"
+	"time"
+	"crypto/tls"
+	"github.com/pkg/errors"
+)
+
+type Sender struct {
+	Address     string
+	SendTimeout int
+	conn        net.Conn
+	err         error
+}
+
+func (s *Sender) write(data []byte) {
+	if s.err != nil {
+		return
+	}
+	defer func() {
+		if s.err != nil && s.conn != nil {
+			s.conn.Close()
+			s.conn = nil
+		}
+	}()
+	var n int
+	if n, s.err = s.conn.Write(data); s.err != nil {
+		s.err = errors.Wrap(s.err, "writing TLS")
+		return
+	}
+	if n != len(data) {
+		s.err = errors.New("short TLS write")
+	}
+}
+
+func (s *Sender) Send(data []byte) (err error) {
+	if s.conn == nil {
+		s.err = nil
+		if s.conn, err = tls.Dial("tcp", s.Address, &tls.Config{} ); err != nil {
+			s.err = errors.Wrap(err, "creating TLS connection")
+			return s.err
+		}
+	}
+	s.conn.SetDeadline(time.Now().Add(time.Duration(s.SendTimeout) * time.Millisecond))
+	s.write(data)
+	s.write([]byte{0})
+	return s.err
+}


### PR DESCRIPTION
Some [managed graylog backend](https://www.ovhcloud.com/en/logs-data-platform/) are exposed through TLS (instead of plain tcp).
This PR add support for that.
Also, please tag your releases on docker hub, if possible (instead of plain "latest")